### PR TITLE
fix: add album functionality  Album. Fix problem with having id on JS…

### DIFF
--- a/app/src/main/java/com/northcoders/vinylrecords/model/Album.java
+++ b/app/src/main/java/com/northcoders/vinylrecords/model/Album.java
@@ -5,11 +5,9 @@ import androidx.databinding.Bindable;
 
 import com.northcoders.vinylrecords.BR;
 
-import java.time.LocalDate;
-
 public class Album extends BaseObservable {
 
-    private long id;
+    private Long id;
     private String title;
     private String description;
     private String artist;
@@ -40,11 +38,11 @@ public class Album extends BaseObservable {
     }
 
     @Bindable
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(long id) {
+    public void setId(Long id) {
         this.id = id;
         // notifyPropertyChanged(BR.id);
     }


### PR DESCRIPTION
…ON sent to API POST request.   Id now stored as Long rather than int

Required because previously when using int, if not provided (as in the case when add new album) defaults to 0. Now as Long, will default to null and not be included in JSON POST request